### PR TITLE
fix(anchor): use the github markdown anchors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -341,7 +341,7 @@ class Header {
         this.title = title;
         this.lineNumber = lineNumber;
         this.lineLength = lineLength;
-        this.anchor = this.title.replace(/[^a-z0-9\-_:\.]|^[^a-z]+/gi, "");
+        this.anchor = this.title.replace(/[^a-z0-9\-_:\.\s]|^[^a-z\s]+/gi, "").replace(/\s/g, "-").toLowerCase();
         this.uniqueAnchor = this.anchor;
   }
 


### PR DESCRIPTION
when editing a page on the markdown wiki, the generated anchors
- are lowercase
- have all the characters except the space replaced with `empty string`
- have all the spaces replaced with `-`